### PR TITLE
patch deserialize bug - set preload content param in API wrapper

### DIFF
--- a/aladdinsdk/api/client.py
+++ b/aladdinsdk/api/client.py
@@ -325,8 +325,8 @@ class AladdinAPI():
 
         request_headers = self._api_auth_util.add_auth_details_to_header_and_config(_oauth_scopes)
 
-        endpoint_to_call = getattr(self.instance, api_endpoint_name) if _deserialize_to_object else getattr(self.instance,
-                                                                                                            f"{api_endpoint_name}_with_http_info")
+        endpoint_to_call = getattr(self.instance, f"{api_endpoint_name}_with_http_info")
+
         sig = self.get_api_endpoint_signature(api_endpoint_name)
 
         if 'body' in sig.parameters.keys():
@@ -335,6 +335,7 @@ class AladdinAPI():
                 vnd_com_blackrock_origin_timestamp=request_headers[_HEADER_KEY_ORIGIN_TIMESTAMP],
                 body=request_body,
                 _headers=request_headers,
+                _preload_content=_deserialize_to_object,
                 **params
             )
         else:
@@ -342,11 +343,15 @@ class AladdinAPI():
                 vnd_com_blackrock_request_id=request_headers[_HEADER_KEY_REQUEST_ID],
                 vnd_com_blackrock_origin_timestamp=request_headers[_HEADER_KEY_ORIGIN_TIMESTAMP],
                 _headers=request_headers,
+                _preload_content=_deserialize_to_object,
                 **params
             )
 
-        if not _deserialize_to_object:
-            # disabled deserialization and response validation - for inaccurate aladdin-graph API protos and/or API server implementations
+        if _deserialize_to_object:
+            if hasattr(api_response, "data"):
+                api_response = api_response.data
+        else:
+            # disabled deserialization and response validation - for to obtain raw response
             if hasattr(api_response, "raw_data"):
                 api_response = json.loads(api_response.raw_data)
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -262,7 +262,7 @@ class TestApiClient(TestCase):
 
         signature_bkp = test_subject.get_api_endpoint_signature('train_journey_api_filter_train_journeys')
 
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             with mock.patch.object(test_subject, 'get_api_endpoint_signature') as mock_signature_helper:
                 mock_filter_call.return_value = "TEST_RESPONSE"
                 mock_signature_helper.return_value = signature_bkp
@@ -273,6 +273,7 @@ class TestApiClient(TestCase):
                     vnd_com_blackrock_request_id=mock.ANY,
                     vnd_com_blackrock_origin_timestamp=mock.ANY,
                     _headers=mock.ANY,
+                    _preload_content=True,
                     body={"payload_key": "payload value"})
             self.assertEqual(resp, 'TEST_RESPONSE')
 
@@ -294,6 +295,7 @@ class TestApiClient(TestCase):
                     vnd_com_blackrock_request_id=mock.ANY,
                     vnd_com_blackrock_origin_timestamp=mock.ANY,
                     _headers=mock.ANY,
+                    _preload_content=False,
                     body={"payload_key": "payload value"})
             self.assertEqual(resp, {"resp_key": "resp_val"})
 
@@ -304,7 +306,7 @@ class TestApiClient(TestCase):
 
         signature_bkp = test_subject.get_api_endpoint_signature('train_journey_api_filter_train_journeys')
 
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             with mock.patch.object(test_subject, 'get_api_endpoint_signature') as mock_signature_helper:
                 class MockApiResp:
                     def json(self):
@@ -343,6 +345,7 @@ class TestApiClient(TestCase):
                     vnd_com_blackrock_request_id=mock.ANY,
                     vnd_com_blackrock_origin_timestamp=mock.ANY,
                     _headers=mock.ANY,
+                    _preload_content=True,
                     body={"payload_key": "payload value"})
             expected_data = {'batters.batter.id': ['1001', '1002', '1003', '1004'],
                              'batters.batter.type': ['Regular', 'Chocolate', 'Blueberry', "Devil's Food"],
@@ -355,7 +358,7 @@ class TestApiClient(TestCase):
 
         test_subject = AladdinAPI('TrainJourneyAPI')
 
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             mock_filter_call.return_value = "TEST_RESPONSE"
 
             resp = test_subject.call_api('train_journey_api_filter_train_journeys', param_key_1="param value 1")
@@ -363,6 +366,8 @@ class TestApiClient(TestCase):
                 vnd_com_blackrock_request_id=mock.ANY,
                 vnd_com_blackrock_origin_timestamp=mock.ANY,
                 _headers=mock.ANY,
+                body=None,
+                _preload_content=True,
                 param_key_1="param value 1")
             self.assertEqual(resp, 'TEST_RESPONSE')
 
@@ -811,7 +816,7 @@ class TestApiOauthRunLocal(TestCase):
     def test_api_client_get_oauth_token_success(self, oauth_token, secret):
         from aladdinsdk.api.client import AladdinAPI
         test_subject = AladdinAPI('TrainJourneyAPI', client_id='id', client_secret='secret', refresh_token='refresh_token')
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             mock_filter_call.return_value = "TEST_RESPONSE"
             test_subject.call_api("train_journey_api_filter_train_journeys", {"test": "body"})
             self.assertIsNotNone(test_subject)

--- a/test/test_common_error_handling.py
+++ b/test/test_common_error_handling.py
@@ -163,13 +163,13 @@ class TestCommonErrorHandlerApiHandler(TestCase):
 
         test_subject = AladdinAPI('TrainJourneyAPI')
 
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             mock_filter_call.side_effect = UnauthorizedException("Mock UnauthorizedException")
             with self.assertRaises(UnauthorizedException) as context:
                 test_subject.call_api('train_journey_api_filter_train_journeys', {"payload_key": "payload value"})
                 self.assertIn("Mock UnauthorizedException", context.exception.message)
 
-        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys') as mock_filter_call:
+        with mock.patch.object(test_subject.instance, 'train_journey_api_filter_train_journeys_with_http_info') as mock_filter_call:
             from pydantic import BaseModel, Field
 
             class A(BaseModel):


### PR DESCRIPTION
patch deserialize bug - set preload content param in API wrapper

## Description

Previously codegen did not require explicit value to be set for preloading content in case deserialization was enabled.

## Changes Made

With this change, depending on deserialize to object parameter in api call methods, set preload content parameter value and read response from data/raw_data attributes

## Definition of Done

Before submitting this pull request, please ensure that the following criteria have been met:

- [x] All automated tests have passed successfully.
- [x] All manual tests have passed successfully.
- [x] Code has been reviewed by at least one other team member.
- [x] Code has been properly documented and commented as needed.
- [x] All new and existing code adheres to our project's coding standards.
- [x] All dependencies have been added or removed from the project's README or other documentation as needed.
- [x] Any relevant documentation or help files have been updated to reflect the changes made in this pull request.
- [x] Any necessary database migrations have been run.
- [x] Any relevant UI changes have been reviewed and approved by the UI/UX team.
